### PR TITLE
Feature/create taskfor new gardening managers2

### DIFF
--- a/.github/workflows/pr-main-branch.yml
+++ b/.github/workflows/pr-main-branch.yml
@@ -162,7 +162,7 @@ jobs:
 
             # Now we upload the .sarif file as explained in the previous step
             - name: Upload SARIF file
-              uses: github/codeql-action/upload-sarif@v1
+              uses: github/codeql-action/upload-sarif@v2
               with:
                 sarif_file: changed-sources/apexScanResults.sarif
 

--- a/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
@@ -20,7 +20,7 @@ public with sharing class TRG_CAMPX_GardenHelper {
      * @param       newTriggerList : Trigger.new
      * @param       oldTriggerMap  : Trigger.oldMap
      * 
-     * @description When a new garden record is created and a manager is assigned, create a new 
+     * @description When a new garden record is created/update and a manager is assigned, create a new 
      *              Task record and assign it to the manager
      * @comments
     **********************************************************************************************/
@@ -29,7 +29,12 @@ public with sharing class TRG_CAMPX_GardenHelper {
         List<Task> taskToInsert = new List<Task>();
         
         for (CAMPX__Garden__c currentGarden : newTriggerList) {
-            if (currentGarden.CAMPX__Manager__c != null || (currentGarden.CAMPX__Manager__c != null && oldTriggerMap?.get(currentGarden.Id).CAMPX__Manager__c != currentGarden.CAMPX__Manager__c)) {
+            if (currentGarden.CAMPX__Manager__c != null && oldTriggerMap == null
+                    || (
+                            currentGarden.CAMPX__Manager__c != null 
+                            && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c != currentGarden.CAMPX__Manager__c
+                        )
+            ) {
                 Task newTask = new Task(
                     WhatId  = currentGarden.Id,
                     OwnerId = currentGarden.CAMPX__Manager__c,

--- a/force-app/main/default/classes/TRG_CAMPX_GardenHelper_Test.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHelper_Test.cls
@@ -164,4 +164,50 @@ public with sharing class TRG_CAMPX_GardenHelper_Test {
 
         System.assertEquals(0, createdTasks.size(), 'Number of created tasks should match number of Garden records');
     }
+
+    /**************************************************************************************************
+     * @author      manvil95
+     * @date        10/05/2024
+     * @modifiedBy
+     * 
+     * @description 
+     * @comments
+    **************************************************************************************************/
+    @isTest
+    static void testCreateTaskAfterUpdateGardenWithManagerFirstTime() {
+        // Create test Garden records
+        List<CAMPX__Garden__c> testGardens = new List<CAMPX__Garden__c>();
+        for (Integer i = 0; i < 5; i++) {
+            CAMPX__Garden__c currentGarden = new CAMPX__Garden__c(
+                Name = 'Garden ' + i
+            );
+            testGardens.add(currentGarden);
+        }
+        insert testGardens;
+        
+        List<CAMPX__Garden__c> updateGardens = new List<CAMPX__Garden__c>();
+        for (CAMPX__Garden__c garden : testGardens) {
+            garden.CAMPX__Manager__c = UserInfo.getUserId();
+            updateGardens.add(garden);
+        }
+
+        System.debug('MVC: TEST: ' + testGardens);
+        
+        // Call the method being tested
+        Test.startTest();
+        
+        update updateGardens;
+
+        Test.stopTest();
+
+        // Verify that tasks have been created for the Garden managers
+        List<Task> createdTasks = [SELECT Id, OwnerId, WhatId, Subject FROM Task WHERE WhatId IN :testGardens];
+        System.assertEquals(testGardens.size(), createdTasks.size(), 'Number of created tasks should match number of Garden records');
+
+        // Verify task ownership and subject
+        for (Task currentTask : createdTasks) {
+            System.assertEquals(testGardens[0].CAMPX__Manager__c, currentTask.OwnerId, 'Task owner should match the Garden manager');
+            System.assertEquals('Acquire Plants', currentTask.Subject, 'Task subject should match the predefined value');
+        }
+    }
 }

--- a/force-app/main/default/classes/TRG_CAMPX_GardenHelper_Test.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHelper_Test.cls
@@ -189,10 +189,7 @@ public with sharing class TRG_CAMPX_GardenHelper_Test {
         for (CAMPX__Garden__c garden : testGardens) {
             garden.CAMPX__Manager__c = UserInfo.getUserId();
             updateGardens.add(garden);
-        }
-
-        System.debug('MVC: TEST: ' + testGardens);
-        
+        }        
         // Call the method being tested
         Test.startTest();
         

--- a/force-app/main/default/triggers/TRG_CAMPX_Garden.trigger
+++ b/force-app/main/default/triggers/TRG_CAMPX_Garden.trigger
@@ -10,6 +10,6 @@
  * @description     Trigger on CAMPX__Garden__c.
  * @comments
  **************************************************************************************************/
-trigger TRG_CAMPX_Garden on CAMPX__Garden__c (before insert, after insert) {
+trigger TRG_CAMPX_Garden on CAMPX__Garden__c (before insert, after insert, after update) {
     new TRG_CAMPX_GardenHandler().run();
 }


### PR DESCRIPTION
### Description

Context from the Product Manager: The product team identified a gap in the requirements. Previously, tasks were only created with new garden records that had a manager assigned. However, it's possible to create a garden record without a manager, and later add a manager. In this scenario, a task wouldn't be created. This update addresses this issue.


User Story:
As a GreenGuardian CRM Director, I want the system to automatically create a task for the newly assigned manager when a garden record, that initially was without a manager, has one assigned. This ensures the new manager is quickly informed and can immediately begin sourcing plants for the garden.


Acceptance Criteria:

When a garden record's manager changes from blank to a non-blank value, a [Task](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_task.htm) record should be created and assigned it to the manager
Just like before, the subject of the task should be "Acquire Plants" and it should be linked to the garden record

Example Scenario:

The Mapleshade Garden has no manager. It's updated and assigned a manager. The system should automatically create a new "Acquire Plants" task for the new manager..

### Apex Tests to Run

Apex::[TRG_CAMPX_GardenHelper_Test,TRG_CAMPX_PlantHelper_Test,TriggerHandler_Test]::Apex