### PR TITLE
Feature/reassign task

### DIFF
--- a/.github/workflows/pr-main-branch.yml
+++ b/.github/workflows/pr-main-branch.yml
@@ -162,7 +162,7 @@ jobs:
 
             # Now we upload the .sarif file as explained in the previous step
             - name: Upload SARIF file
-              uses: github/codeql-action/upload-sarif@v2
+              uses: github/codeql-action/upload-sarif@v3
               with:
                 sarif_file: changed-sources/apexScanResults.sarif
 

--- a/.github/workflows/pr-main-branch.yml
+++ b/.github/workflows/pr-main-branch.yml
@@ -30,10 +30,10 @@ jobs:
         runs-on: ubuntu-latest
         if: ${{ github.actor != 'dependabot[bot]' }}
         steps:
-            # Now we install nodejs in the VM, and specify version 14
+            # Now we install nodejs in the VM, and specify the latest LTS version
             - uses: actions/setup-node@v3
               with:
-                node-version: '14'
+                node-version: 'lts/*'
 
             # The idea is that the VM can access your remote repository
             # because your repository is an sfdx project.

--- a/force-app/main/default/classes/TRG_CAMPX_GardenHandler.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHandler.cls
@@ -45,7 +45,7 @@ public with sharing class TRG_CAMPX_GardenHandler extends TriggerHandler{
      * @comments
     **************************************************************************************************/
     public override void afterInsert() {
-        TRG_CAMPX_GardenHelper.CreateTaskForNewGardeningManagers(this.listNew, null);
+        TRG_CAMPX_GardenHelper.createTaskForNewGardeningManagers(this.listNew, null);
     }
 
     /**************************************************************************************************
@@ -56,6 +56,7 @@ public with sharing class TRG_CAMPX_GardenHandler extends TriggerHandler{
      * @comments
     **************************************************************************************************/
     public override void afterUpdate() {
-        TRG_CAMPX_GardenHelper.CreateTaskForNewGardeningManagers(this.listNew, this.mapOld);
+        TRG_CAMPX_GardenHelper.createTaskForNewGardeningManagers(this.listNew, this.mapOld);
+        TRG_CAMPX_GardenHelper.reassingTaskWhenManagerChanges(this.listNew, this.mapOld);
     }
 }

--- a/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
@@ -24,7 +24,7 @@ public with sharing class TRG_CAMPX_GardenHelper {
      *              Task record and assign it to the manager
      * @comments
     **********************************************************************************************/
-    public static void CreateTaskForNewGardeningManagers(List<CAMPX__Garden__c> newTriggerList, Map<Id, CAMPX__Garden__c> oldTriggerMap) {
+    public static void createTaskForNewGardeningManagers(List<CAMPX__Garden__c> newTriggerList, Map<Id, CAMPX__Garden__c> oldTriggerMap) {
         List<Task> newTasks = new List<Task>();
         List<Task> taskToInsert = new List<Task>();
         
@@ -33,6 +33,7 @@ public with sharing class TRG_CAMPX_GardenHelper {
                     || (
                             currentGarden.CAMPX__Manager__c != null 
                             && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c != currentGarden.CAMPX__Manager__c
+                            && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c == null
                         )
             ) {
                 Task newTask = new Task(
@@ -49,6 +50,58 @@ public with sharing class TRG_CAMPX_GardenHelper {
             insert taskToInsert;
         } catch (Exception e) {
             System.debug(e.getMessage());
+        }
+    }
+
+    /**********************************************************************************************
+     * @author      manvil95
+     * @date        10/05/2024
+     * @modifiedBy
+     * 
+     * @param       newTriggerList : Trigger.new
+     * @param       oldTriggerMap  : Trigger.oldMap
+     * 
+     * @description When a new garden record is created/update and a manager is assigned, create a new 
+     *              Task record and assign it to the manager
+     * @comments
+    **********************************************************************************************/
+    public static void reassingTaskWhenManagerChanges(List<CAMPX__Garden__c> newTriggerList, Map<Id, CAMPX__Garden__c> oldTriggerMap) {
+        List<Task> tasks = new List<Task>();
+        List<Task> taskToUpdate = new List<Task>();
+        Set<Id> gardenIds = new Set<Id>();
+
+        
+        for (CAMPX__Garden__c currentGarden : newTriggerList) {
+            if (currentGarden.CAMPX__Manager__c != null
+                    && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c != null 
+                    && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c != currentGarden.CAMPX__Manager__c
+                
+            ) {
+                gardenIds.add(currentGarden.Id);
+            }
+        }
+
+        if (!gardenIds.isEmpty()) {
+            tasks = [SELECT Id, WhatId, OwnerId 
+                    FROM Task 
+                    WHERE WhatId IN :gardenIds 
+                        AND Status != 'Completed' 
+                    WITH USER_MODE];
+            
+            for (CAMPX__Garden__c currentGarden : newTriggerList) {
+                for (Task currentTask : tasks) {
+                    if (currentGarden.Id == currentTask.WhatId) {
+                        currentTask.OwnerId = currentGarden.CAMPX__Manager__c;
+                        taskToUpdate.add(currentTask);
+                    }
+                }
+            }
+            
+            try {
+                update taskToUpdate;
+            } catch (Exception e) {
+                System.debug(e.getMessage());
+            }
         }
     }
 

--- a/force-app/main/default/classes/TRG_CAMPX_GardenHelper_Test.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHelper_Test.cls
@@ -15,7 +15,23 @@ public with sharing class TRG_CAMPX_GardenHelper_Test {
     
     @TestSetup
     static void makeData(){
-        
+        // Create a profile for Admin
+        Profile adminProfile = [SELECT Id FROM Profile WHERE Name = 'System Administrator' LIMIT 1];
+
+        // Create a user with the admin profile
+        User adminUser = new User(
+            FirstName           = 'Test',
+            LastName            = 'Admin',
+            Alias               = 'tadmin',
+            Email               = 'testadmin@example.com',
+            Username            = 'manvil95@campapexgreen.com', // Ensure unique username
+            EmailEncodingKey    = 'UTF-8',
+            TimeZoneSidKey      = 'Europe/Madrid',
+            LocaleSidKey        = 'en_US',
+            LanguageLocaleKey   = 'en_US',
+            ProfileId           = adminProfile.Id
+        );
+        insert adminUser;
     }
 
     /**************************************************************************************************
@@ -204,6 +220,57 @@ public with sharing class TRG_CAMPX_GardenHelper_Test {
         // Verify task ownership and subject
         for (Task currentTask : createdTasks) {
             System.assertEquals(testGardens[0].CAMPX__Manager__c, currentTask.OwnerId, 'Task owner should match the Garden manager');
+            System.assertEquals('Acquire Plants', currentTask.Subject, 'Task subject should match the predefined value');
+        }
+    }
+
+    /**************************************************************************************************
+     * @author      manvil95
+     * @date        10/05/2024
+     * @modifiedBy
+     * 
+     * @description 
+     * @comments
+    **************************************************************************************************/
+    @isTest
+    static void testReassignTasks() {
+        // Create test Garden records
+        List<CAMPX__Garden__c> testGardens = new List<CAMPX__Garden__c>();
+        for (Integer i = 0; i < 5; i++) {
+            CAMPX__Garden__c currentGarden = new CAMPX__Garden__c(
+                Name = 'Garden ' + i,
+                CAMPX__Manager__c = UserInfo.getUserId()
+            );
+            testGardens.add(currentGarden);
+        }
+        
+        User u = [SELECT Id FROM User WHERE Username = 'manvil95@campapexgreen.com' LIMIT 1];
+        
+        insert testGardens;
+        List<CAMPX__Garden__c> updateGardens = new List<CAMPX__Garden__c>();
+        for (CAMPX__Garden__c garden : testGardens) {
+            garden.CAMPX__Manager__c = u.Id;
+            updateGardens.add(garden);
+        }        
+        // Call the method being tested
+        Test.startTest();
+        
+        update updateGardens;
+
+        Test.stopTest();
+
+        List<CAMPX__Garden__c> updatedGardens = [SELECT Id, CAMPX__Manager__c FROM CAMPX__Garden__c];
+        // Verify that tasks have been created for the Garden managers
+        List<Task> createdTasks = [SELECT Id, OwnerId, WhatId, Subject FROM Task WHERE WhatId IN :updatedGardens];
+        System.assertEquals(updatedGardens.size(), createdTasks.size(), 'Number of created tasks should match number of Garden records');
+        
+        // Verify task ownership and subject
+        for (CAMPX__Garden__c updated : updatedGardens) {
+            System.assertEquals(updated.CAMPX__Manager__c, u.Id, 'Task owner should match the Garden manager');
+        }
+        
+        for (Task currentTask : createdTasks) {
+            System.assertEquals(updatedGardens[0].CAMPX__Manager__c, currentTask.OwnerId, 'Task owner should match the Garden manager');
             System.assertEquals('Acquire Plants', currentTask.Subject, 'Task subject should match the predefined value');
         }
     }


### PR DESCRIPTION
### Description

User Story:
As a GreenGuardian CRM Director, I need the system to transfer open "Acquire Plants" tasks from a departing manager to the incoming manager, so that the new manager is informed of all outstanding tasks.


Acceptance Criteria:

When a garden's manager is updated to reassign a manager, any task record that meets this criteria should also be reassigned
Status: Not "Completed"
OwnerId: The previous manager
Subject: Acquire Plants
WhatId: The garden's Id

Example Scenarios:

When Lauren takes over for Michael as the manager of Evergreen Gardens, Michael's open task is reassigned to Lauren
When Adam takes over for Steven, Steven's completed task remains assigned to Steven.

### Apex Tests to Run

Apex::[TRG_CAMPX_GardenHelper_Test,TRG_CAMPX_PlantHelper_Test,TriggerHandler_Test]::Apex