### PR TITLE
Feature/set manager start date

### DIFF
--- a/force-app/main/default/classes/TRG_CAMPX_GardenHandler.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHandler.cls
@@ -35,6 +35,7 @@ public with sharing class TRG_CAMPX_GardenHandler extends TriggerHandler{
     **************************************************************************************************/
     public override void beforeInsert() {
         TRG_CAMPX_GardenHelper.initializeGardenFieldsUponRecordCreation(this.listNew);
+        TRG_CAMPX_GardenHelper.setUnsetManagerStartDate(this.listNew, null);
     }
     
     /**************************************************************************************************
@@ -46,6 +47,17 @@ public with sharing class TRG_CAMPX_GardenHandler extends TriggerHandler{
     **************************************************************************************************/
     public override void afterInsert() {
         TRG_CAMPX_GardenHelper.createTaskForNewGardeningManagers(this.listNew, null);
+    }
+
+    /**************************************************************************************************
+     * @author      manvil95
+     * @date        24/05/2024
+     * @modifiedBy
+     * @description Handler method on before update.
+     * @comments
+    **************************************************************************************************/
+    public override void beforeUpdate() {
+        TRG_CAMPX_GardenHelper.setUnsetManagerStartDate(this.listNew, this.mapOld);
     }
 
     /**************************************************************************************************

--- a/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
@@ -17,6 +17,67 @@ public with sharing class TRG_CAMPX_GardenHelper {
 
     /**********************************************************************************************
      * @author      manvil95
+     * @date        24/05/2024
+     * @modifiedBy
+     * 
+     * @param       newTriggerList : Trigger.new
+     * @param       oldTriggerMap  : Trigger.oldMap
+     * 
+     * @description When a new garden record is created/update and a manager is assigned/unassigned, 
+     *              the start date must be set/unset.
+     * @comments
+    **********************************************************************************************/
+    public static void setUnsetManagerStartDate(List<CAMPX__Garden__c> newTriggerList, Map<Id, CAMPX__Garden__c> oldTriggerMap) {
+        List<CAMPX__Garden__c> gardensToUpdate              = new List<CAMPX__Garden__c>();
+        List<CAMPX__Garden__c> gardensToUpdateWithDate      = new List<CAMPX__Garden__c>();
+        List<CAMPX__Garden__c> gardensToUpdateWithoutDate   = new List<CAMPX__Garden__c>();
+        
+        for (CAMPX__Garden__c currentGarden : newTriggerList) {
+            if (currentGarden.CAMPX__Manager__c != null && oldTriggerMap == null
+                    || (
+                            currentGarden.CAMPX__Manager__c != null 
+                            && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c != currentGarden.CAMPX__Manager__c
+                            && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c == null
+                        )
+            ) {
+                gardensToUpdateWithDate.add(currentGarden);
+                continue;
+            }
+            
+            try {
+                if (currentGarden.CAMPX__Manager__c == null
+                    && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c != null 
+                    && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c != currentGarden.CAMPX__Manager__c
+                ) {
+                    gardensToUpdateWithoutDate.add(currentGarden);
+                }
+            } catch (Exception e) {
+                System.debug(e.getMessage());
+            }
+        }
+
+        for (CAMPX__Garden__c currentGarden : gardensToUpdateWithDate) {
+            currentGarden.CAMPX__Manager_Start_Date__c = Date.today();
+            gardensToUpdate.add(currentGarden);
+        }
+        
+        for (CAMPX__Garden__c currentGarden : gardensToUpdateWithoutDate) {
+            currentGarden.CAMPX__Manager_Start_Date__c = null;
+            gardensToUpdate.add(currentGarden);
+        }
+
+        
+        if (!gardensToUpdate.isEmpty()) {
+            try {
+                update gardensToUpdate;
+            } catch (Exception e) {
+                System.debug(e.getMessage());
+            }
+        }
+    }
+
+    /**********************************************************************************************
+     * @author      manvil95
      * @date        10/05/2024
      * @modifiedBy
      * 
@@ -111,6 +172,7 @@ public with sharing class TRG_CAMPX_GardenHelper {
             }
         }
     }
+
     /**********************************************************************************************
      * @author      manvil95
      * @date        10/05/2024

--- a/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
@@ -28,50 +28,22 @@ public with sharing class TRG_CAMPX_GardenHelper {
      * @comments
     **********************************************************************************************/
     public static void setUnsetManagerStartDate(List<CAMPX__Garden__c> newTriggerList, Map<Id, CAMPX__Garden__c> oldTriggerMap) {
-        List<CAMPX__Garden__c> gardensToUpdate              = new List<CAMPX__Garden__c>();
-        List<CAMPX__Garden__c> gardensToUpdateWithDate      = new List<CAMPX__Garden__c>();
-        List<CAMPX__Garden__c> gardensToUpdateWithoutDate   = new List<CAMPX__Garden__c>();
         
         for (CAMPX__Garden__c currentGarden : newTriggerList) {
-            if (currentGarden.CAMPX__Manager__c != null && oldTriggerMap == null
+            if ((currentGarden.CAMPX__Manager__c != null && oldTriggerMap == null)
                     || (
                             currentGarden.CAMPX__Manager__c != null 
                             && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c != currentGarden.CAMPX__Manager__c
-                            && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c == null
                         )
             ) {
-                gardensToUpdateWithDate.add(currentGarden);
-                continue;
+                currentGarden.CAMPX__Manager_Start_Date__c = Date.today();
             }
             
-            try {
-                if (currentGarden.CAMPX__Manager__c == null
-                    && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c != null 
-                    && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c != currentGarden.CAMPX__Manager__c
-                ) {
-                    gardensToUpdateWithoutDate.add(currentGarden);
-                }
-            } catch (Exception e) {
-                System.debug(e.getMessage());
-            }
-        }
-
-        for (CAMPX__Garden__c currentGarden : gardensToUpdateWithDate) {
-            currentGarden.CAMPX__Manager_Start_Date__c = Date.today();
-            gardensToUpdate.add(currentGarden);
-        }
-        
-        for (CAMPX__Garden__c currentGarden : gardensToUpdateWithoutDate) {
-            currentGarden.CAMPX__Manager_Start_Date__c = null;
-            gardensToUpdate.add(currentGarden);
-        }
-
-        
-        if (!gardensToUpdate.isEmpty()) {
-            try {
-                update gardensToUpdate;
-            } catch (Exception e) {
-                System.debug(e.getMessage());
+            if ((currentGarden.CAMPX__Manager__c == null && oldTriggerMap == null) || (currentGarden.CAMPX__Manager__c == null
+                    && oldTriggerMap.get(currentGarden.Id) != null 
+                    && oldTriggerMap.get(currentGarden.Id).CAMPX__Manager__c != null)
+            ) {
+                currentGarden.CAMPX__Manager_Start_Date__c = null;
             }
         }
     }
@@ -237,8 +209,6 @@ public with sharing class TRG_CAMPX_GardenHelper {
      * @comments
     **********************************************************************************************/
     public static void initializeGardenFieldsUponRecordCreation(List<CAMPX__Garden__c> newTriggerList) {
-        List<CAMPX__Garden__c> gardensToInsert = new List<CAMPX__Garden__c>();
-        
         for (CAMPX__Garden__c currentGarden : newTriggerList) {
             if (currentGarden.CAMPX__Status__c == null || currentGarden.CAMPX__Status__c == '') {
                 currentGarden.CAMPX__Status__c = 'Awaiting Resources';
@@ -259,14 +229,6 @@ public with sharing class TRG_CAMPX_GardenHelper {
             if (currentGarden.CAMPX__Total_Unhealthy_Plant_Count__c == null) {
                 currentGarden.CAMPX__Total_Unhealthy_Plant_Count__c = 0;
             }
-            
-            gardensToInsert.add(currentGarden);
-        }
-        
-        try {
-            insert gardensToInsert;
-        } catch (Exception e) {
-            System.debug(e.getMessage());
         }
     }
 }

--- a/force-app/main/default/triggers/TRG_CAMPX_Garden.trigger
+++ b/force-app/main/default/triggers/TRG_CAMPX_Garden.trigger
@@ -10,6 +10,6 @@
  * @description     Trigger on CAMPX__Garden__c.
  * @comments
  **************************************************************************************************/
-trigger TRG_CAMPX_Garden on CAMPX__Garden__c (before insert, after insert, after update) {
+trigger TRG_CAMPX_Garden on CAMPX__Garden__c (before insert, after insert, before update, after update) {
     new TRG_CAMPX_GardenHandler().run();
 }


### PR DESCRIPTION
### Description

#### Note from the Product Manager:
One more task requirement.... Just kidding! We're done with that.


#### User Story:
As a GreenGuardian CRM Director, I want the system to capture the manager's start date on the garden record, so that I can report on when a manager started working at the garden.


#### Acceptance Criteria:

The "Manager Start Date" (CAMPX__Manager_Start_Date__c) should be set in the following scenarios:
When a manager is assigned, the field must be set with the current date
When a manager is unassigned and no replacement is named, the field must be cleared

#### Example Scenario:

When Elise is assigned as the manager of Orchard Valley Garden on April 15th, the system sets her start date to April 15th, reflecting her first day in charge of the garden.
If the manager of Rose Garden steps down on June 1st and no new manager is immediately assigned, the system automatically clears the start date field

### Apex Tests to Run

Apex::[TRG_CAMPX_GardenHelper_Test,TRG_CAMPX_PlantHelper_Test,TriggerHandler_Test]::Apex