### PR TITLE
Feature/aggregate total plant count

### DIFF
--- a/force-app/main/default/classes/TRG_CAMPX_GardenHelper_Test.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHelper_Test.cls
@@ -36,7 +36,7 @@ public with sharing class TRG_CAMPX_GardenHelper_Test {
 
     /**************************************************************************************************
      * @author      manvil95
-     * @date        10/05/2024
+     * @date        25/05/2024
      * @modifiedBy
      * @description When a garden record is updated and a manager is unset, start date must be blank.
      * @comments
@@ -75,7 +75,7 @@ public with sharing class TRG_CAMPX_GardenHelper_Test {
 
     /**************************************************************************************************
      * @author      manvil95
-     * @date        10/05/2024
+     * @date        25/05/2024
      * @modifiedBy
      * @description When a new garden record is created and a manager is set, start date must be filled.
      * @comments

--- a/force-app/main/default/classes/TRG_CAMPX_PlantHandler.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_PlantHandler.cls
@@ -36,4 +36,37 @@ public with sharing class TRG_CAMPX_PlantHandler extends TriggerHandler {
     public override void beforeInsert() { 
         TRG_CAMPX_PlantHelper.initializePlantFields(this.listNew);
     }
+
+    /**************************************************************************************************
+     * @author      manvil95
+     * @date        25/05/2024
+     * @modifiedBy
+     * @description Handler method on after insert.
+     * @comments
+    **************************************************************************************************/
+    public override void afterInsert() { 
+        TRG_CAMPX_PlantHelper.aggregateTotalPlantCount(this.listNew, null);
+    }
+    
+    /**************************************************************************************************
+     * @author      manvil95
+     * @date        25/05/2024
+     * @modifiedBy
+     * @description Handler method on after update.
+     * @comments
+     **************************************************************************************************/
+    public override void afterUpdate() { 
+        TRG_CAMPX_PlantHelper.aggregateTotalPlantCount(this.listNew, this.mapOld);
+    }
+    
+    /**************************************************************************************************
+     * @author      manvil95
+     * @date        25/05/2024
+     * @modifiedBy
+     * @description Handler method on after delete.
+     * @comments
+    **************************************************************************************************/
+    public override void afterDelete() {
+        TRG_CAMPX_PlantHelper.aggregateTotalPlantCount(this.listOld, null);
+    }
 }

--- a/force-app/main/default/classes/TRG_CAMPX_PlantHelper.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_PlantHelper.cls
@@ -18,6 +18,49 @@ public with sharing class TRG_CAMPX_PlantHelper {
      * @modifiedBy
      * 
      * @param       newTriggerList : Trigger.new
+     * @param       oldTriggerMap  : Trigger.oldMap
+     * 
+     * @description When a Plant record is associated with a garden, the total count of the garden
+     *              must set to the total count of the plants.
+     * @comments
+    **********************************************************************************************/
+    public static void aggregateTotalPlantCount(List<CAMPX__Plant__c> newTriggerList, Map<Id, CAMPX__Plant__c> oldMap) {
+        List<CAMPX__Garden__c> gardensToUpdate;
+        Set<Id> gardenIds = new Set<Id>();
+
+        for (CAMPX__Plant__c currentPlant : newTriggerList) {
+            gardenIds.add(currentPlant.CAMPX__Garden__c);
+
+            if (oldMap != null && currentPlant.CAMPX__Garden__c != oldMap.get(currentPlant.Id).CAMPX__Garden__c) {
+                gardenIds.add(oldMap.get(currentPlant.Id).CAMPX__Garden__c);
+            }
+        }
+        if (!gardenIds.isEmpty()) {
+            
+            gardensToUpdate = [SELECT Id, 
+                                    CAMPX__Total_Plant_Count__c, 
+                                    (   
+                                        SELECT Id 
+                                        FROM CAMPX__Plants__r
+                                    )
+                            FROM CAMPX__Garden__c
+                            WHERE Id IN :gardenIds
+                            WITH USER_MODE];
+                            
+            for (CAMPX__Garden__c currentGarden : gardensToUpdate) {
+                currentGarden.CAMPX__Total_Plant_Count__c = currentGarden.CAMPX__Plants__r.size();
+            }
+
+            update gardensToUpdate;
+        }
+    }
+
+    /**********************************************************************************************
+     * @author      manvil95
+     * @date        10/05/2024
+     * @modifiedBy
+     * 
+     * @param       newTriggerList : Trigger.new
      * 
      * @description When a new Plant record is created, each field should be populated with its 
      *              predefined default value if it's blank.

--- a/force-app/main/default/classes/TRG_CAMPX_PlantHelper_Test.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_PlantHelper_Test.cls
@@ -15,6 +15,54 @@ public with sharing class TRG_CAMPX_PlantHelper_Test {
 
     /**************************************************************************************************
      * @author      manvil95
+     * @date        25/05/2024
+     * @modifiedBy
+     * @description When a new plant record is created and associated with a garden, total count must be
+     *              set.
+     * @comments
+    **************************************************************************************************/
+    @isTest
+    static void testAggregateTotalPlantCount() {
+        List<CAMPX__Plant__c> plantsToInsert = new List<CAMPX__Plant__c>();
+        CAMPX__Garden__c garden = new CAMPX__Garden__c(
+            Name = 'Test Garden',
+            CAMPX__Sun_Exposure__c = 'Full Sun'
+        );
+        insert garden;
+
+        CAMPX__Plant__c plant = new CAMPX__Plant__c(
+            Name = 'Test Plant',
+            CAMPX__Garden__c = garden.Id,
+            CAMPX__Soil_Type__c = null,
+            CAMPX__Water__c = null,
+            CAMPX__Sunlight__c = null
+        );
+        plantsToInsert.add(plant);
+        CAMPX__Plant__c plant2 = new CAMPX__Plant__c(
+            Name = 'Test Plant2,
+            CAMPX__Garden__c = garden.Id,
+            CAMPX__Soil_Type__c = null,
+            CAMPX__Water__c = null,
+            CAMPX__Sunlight__c = null
+        );
+        plantsToInsert.add(plant2);
+
+        Test.startTest();
+        insert plantsToInsert;
+        Test.stopTest();
+
+        CAMPX__Garden__c garden = [SELECT Id, CAMPX__Total_Plant_Count__c 
+                                    FROM CAMPX__Garden__c
+                                    LIMIT 1];
+
+        List<CAMPX__Plant__c> plantsCreated = [SELECT Id, CAMPX__Garden__c FROM CAMPX__Plant__c];
+        // FINISH THAT
+        System.assertEquals('All Purpose Potting Soil', plant.CAMPX__Soil_Type__c, 'Soil Type not set');
+        System.assertEquals('Once Weekly', plant.CAMPX__Water__c, 'Watering Schedule not set');
+        System.assertEquals('Full Sun', plant.CAMPX__Sunlight__c, 'Sun Exposure not set');
+    }
+    /**************************************************************************************************
+     * @author      manvil95
      * @date        10/05/2024
      * @modifiedBy
      * @description When a new plant record is created, each field should be populated with its 
@@ -28,8 +76,6 @@ public with sharing class TRG_CAMPX_PlantHelper_Test {
             CAMPX__Sun_Exposure__c = 'Full Sun'
         );
         insert garden;
-
-        System.debug('GARDEN: ' + garden);
 
         CAMPX__Plant__c plant = new CAMPX__Plant__c(
             Name = 'Test Plant',

--- a/force-app/main/default/classes/TRG_CAMPX_PlantHelper_Test.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_PlantHelper_Test.cls
@@ -15,6 +15,98 @@ public with sharing class TRG_CAMPX_PlantHelper_Test {
 
     /**************************************************************************************************
      * @author      manvil95
+     * @date        27/05/2024
+     * @modifiedBy
+     * @description When a new plant record is deleted, total count must be set.
+     * @comments
+    **************************************************************************************************/
+    @isTest
+    static void testAggregateTotalPlantCountWithPlantDeleted() {
+        List<CAMPX__Plant__c> plantsToInsert = new List<CAMPX__Plant__c>();
+        CAMPX__Garden__c garden = new CAMPX__Garden__c(
+            Name = 'Test Garden',
+            CAMPX__Sun_Exposure__c = 'Full Sun'
+        );
+        insert garden;
+
+        CAMPX__Plant__c plant = new CAMPX__Plant__c(
+            Name = 'Test Plant',
+            CAMPX__Garden__c = garden.Id
+        );
+        plantsToInsert.add(plant);
+        CAMPX__Plant__c plant2 = new CAMPX__Plant__c(
+            Name = 'Test Plant2',
+            CAMPX__Garden__c = garden.Id
+        );
+        plantsToInsert.add(plant2);
+        insert plantsToInsert;
+
+        Test.startTest();
+        delete plant2;
+        Test.stopTest();
+
+        CAMPX__Garden__c gardenInserted = [SELECT Id, CAMPX__Total_Plant_Count__c 
+                                            FROM CAMPX__Garden__c
+                                            LIMIT 1];
+
+        List<CAMPX__Plant__c> plantsCreated = [SELECT Id, CAMPX__Garden__c FROM CAMPX__Plant__c WHERE CAMPX__Garden__c != null];
+        
+        System.assertEquals(1, plantsCreated.size(), 'Total Plant Count must be one');
+        System.assertEquals(1, gardenInserted.CAMPX__Total_Plant_Count__c, 'Total Plant Count not set');
+        for (CAMPX__Plant__c plantCreated : plantsCreated) {
+            System.assertEquals(gardenInserted.Id, plantCreated.CAMPX__Garden__c, 'Garden Id not set');
+        }
+    }
+    
+    /**************************************************************************************************
+     * @author      manvil95
+     * @date        27/05/2024
+     * @modifiedBy
+     * @description When a new plant record is updated and not associated with a garden, total count must be
+     *              set.
+     * @comments
+    **************************************************************************************************/
+    @isTest
+    static void testAggregateTotalPlantCountWithGardenUnset() {
+        List<CAMPX__Plant__c> plantsToInsert = new List<CAMPX__Plant__c>();
+        CAMPX__Garden__c garden = new CAMPX__Garden__c(
+            Name = 'Test Garden',
+            CAMPX__Sun_Exposure__c = 'Full Sun'
+        );
+        insert garden;
+
+        CAMPX__Plant__c plant = new CAMPX__Plant__c(
+            Name = 'Test Plant',
+            CAMPX__Garden__c = garden.Id
+        );
+        plantsToInsert.add(plant);
+        CAMPX__Plant__c plant2 = new CAMPX__Plant__c(
+            Name = 'Test Plant2',
+            CAMPX__Garden__c = garden.Id
+        );
+        plantsToInsert.add(plant2);
+        insert plantsToInsert;
+
+        plant2.CAMPX__Garden__c = null;
+
+        Test.startTest();
+        update plant2;
+        Test.stopTest();
+
+        CAMPX__Garden__c gardenInserted = [SELECT Id, CAMPX__Total_Plant_Count__c 
+                                            FROM CAMPX__Garden__c
+                                            LIMIT 1];
+
+        List<CAMPX__Plant__c> plantsCreated = [SELECT Id, CAMPX__Garden__c FROM CAMPX__Plant__c WHERE CAMPX__Garden__c != null];
+        
+        System.assertEquals(1, gardenInserted.CAMPX__Total_Plant_Count__c, 'Total Plant Count not set');
+        for (CAMPX__Plant__c plantCreated : plantsCreated) {
+            System.assertEquals(gardenInserted.Id, plantCreated.CAMPX__Garden__c, 'Garden Id not set');
+        }
+    }
+
+    /**************************************************************************************************
+     * @author      manvil95
      * @date        25/05/2024
      * @modifiedBy
      * @description When a new plant record is created and associated with a garden, total count must be
@@ -32,18 +124,12 @@ public with sharing class TRG_CAMPX_PlantHelper_Test {
 
         CAMPX__Plant__c plant = new CAMPX__Plant__c(
             Name = 'Test Plant',
-            CAMPX__Garden__c = garden.Id,
-            CAMPX__Soil_Type__c = null,
-            CAMPX__Water__c = null,
-            CAMPX__Sunlight__c = null
+            CAMPX__Garden__c = garden.Id
         );
         plantsToInsert.add(plant);
         CAMPX__Plant__c plant2 = new CAMPX__Plant__c(
-            Name = 'Test Plant2,
-            CAMPX__Garden__c = garden.Id,
-            CAMPX__Soil_Type__c = null,
-            CAMPX__Water__c = null,
-            CAMPX__Sunlight__c = null
+            Name = 'Test Plant2',
+            CAMPX__Garden__c = garden.Id
         );
         plantsToInsert.add(plant2);
 
@@ -51,15 +137,16 @@ public with sharing class TRG_CAMPX_PlantHelper_Test {
         insert plantsToInsert;
         Test.stopTest();
 
-        CAMPX__Garden__c garden = [SELECT Id, CAMPX__Total_Plant_Count__c 
-                                    FROM CAMPX__Garden__c
-                                    LIMIT 1];
+        CAMPX__Garden__c gardenInserted = [SELECT Id, CAMPX__Total_Plant_Count__c 
+                                            FROM CAMPX__Garden__c
+                                            LIMIT 1];
 
         List<CAMPX__Plant__c> plantsCreated = [SELECT Id, CAMPX__Garden__c FROM CAMPX__Plant__c];
-        // FINISH THAT
-        System.assertEquals('All Purpose Potting Soil', plant.CAMPX__Soil_Type__c, 'Soil Type not set');
-        System.assertEquals('Once Weekly', plant.CAMPX__Water__c, 'Watering Schedule not set');
-        System.assertEquals('Full Sun', plant.CAMPX__Sunlight__c, 'Sun Exposure not set');
+        
+        System.assertEquals(2, gardenInserted.CAMPX__Total_Plant_Count__c, 'Total Plant Count not set');
+        for (CAMPX__Plant__c plantCreated : plantsCreated) {
+            System.assertEquals(gardenInserted.Id, plantCreated.CAMPX__Garden__c, 'Garden Id not set');
+        }
     }
     /**************************************************************************************************
      * @author      manvil95

--- a/force-app/main/default/triggers/TRG_CAMPX_Plant.trigger
+++ b/force-app/main/default/triggers/TRG_CAMPX_Plant.trigger
@@ -10,6 +10,6 @@
  * @description     Trigger on CAMPX__Plant__c.
  * @comments
  **************************************************************************************************/
-trigger TRG_CAMPX_Plant on CAMPX__Plant__c (before insert) {
+trigger TRG_CAMPX_Plant on CAMPX__Plant__c (before insert, after insert, after update, after delete) {
     new TRG_CAMPX_PlantHandler().run();
 }


### PR DESCRIPTION
### Description

#### User Story:
As a Garden Manager, I want to capture the total number of plants in a garden when a plant is added or removed, so that I can accurately report on the number of plants in each garden at all times.


#### Acceptance Criteria:

The garden's "Total Plant Count" (CAMPX__Total_Plant_Count__c) field should increase when a plant is associated to a garden and decrease when a plant is removed from the garden
A plant is also considered removed from a garden when the plant is deleted

#### Example Scenario:

The rose garden's total plant count is 15. A new rose bush is added, so the total plant count increases to 16
A plant is moved from one garden to another, the total plant count for the first garden decreases and increases for the second
A plant record is deleted, it's former garden's total plant count decreases by one


### Apex Tests to Run

Apex::[TRG_CAMPX_GardenHelper_Test,TRG_CAMPX_PlantHelper_Test,TriggerHandler_Test]::Apex