### PR TITLE
Feature/calculate capacity

### DIFF
--- a/force-app/main/default/classes/TRG_CAMPX_GardenHandler.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHandler.cls
@@ -36,6 +36,7 @@ public with sharing class TRG_CAMPX_GardenHandler extends TriggerHandler{
     public override void beforeInsert() {
         TRG_CAMPX_GardenHelper.initializeGardenFieldsUponRecordCreation(this.listNew);
         TRG_CAMPX_GardenHelper.setUnsetManagerStartDate(this.listNew, null);
+        TRG_CAMPX_GardenHelper.calculateCapacity(this.listNew, null);
     }
     
     /**************************************************************************************************
@@ -58,6 +59,7 @@ public with sharing class TRG_CAMPX_GardenHandler extends TriggerHandler{
     **************************************************************************************************/
     public override void beforeUpdate() {
         TRG_CAMPX_GardenHelper.setUnsetManagerStartDate(this.listNew, this.mapOld);
+        TRG_CAMPX_GardenHelper.calculateCapacity(this.listNew, this.mapOld);
     }
 
     /**************************************************************************************************

--- a/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
@@ -10,11 +10,41 @@
  * @description     Helper class for on TRG_CAMPX_GardenHandler.
  * @comments
  **************************************************************************************************/
+@SuppressWarnings('PMD.CognitiveComplexity')
 public with sharing class TRG_CAMPX_GardenHelper {
     
     private static final String NEW_TASK_SUBJECT = 'Acquire Plants';
     private static final String STATUS_COMPLETED = 'Completed';
 
+    /**********************************************************************************************
+     * @author      manvil95
+     * @date        04/06/2024
+     * @modifiedBy
+     * 
+     * @param       newTriggerList : Trigger.new
+     * @param       oldTriggerMap  : Trigger.oldMap
+     * 
+     * @description Method to calculate the capacity of a garden.
+     * @comments
+    **********************************************************************************************/
+    public static void calculateCapacity(List<CAMPX__Garden__c> newTriggerList, Map<Id, CAMPX__Garden__c> oldTriggerMap) {
+        for (CAMPX__Garden__c currentGarden : newTriggerList) {
+            if ((currentGarden.CAMPX__Total_Plant_Count__c == 0 || currentGarden.CAMPX__Max_Plant_Count__c == 0 
+                    || currentGarden.CAMPX__Total_Plant_Count__c == null || currentGarden.CAMPX__Max_Plant_Count__c == null) 
+                    && (oldTriggerMap != null || oldTriggerMap == null)
+            ) {
+                currentGarden.CAMPX__Capacity__c = 0;
+                continue;
+            }
+
+            if (currentGarden.CAMPX__Total_Plant_Count__c != null && currentGarden.CAMPX__Max_Plant_Count__c != null && (oldTriggerMap != null || oldTriggerMap == null)) {
+                currentGarden.CAMPX__Capacity__c = (currentGarden.CAMPX__Total_Plant_Count__c / currentGarden.CAMPX__Max_Plant_Count__c * 100);
+                System.debug('NOT 0 -> ' + currentGarden.CAMPX__Capacity__c);
+                continue;
+            }
+        }
+    }
+    
     /**********************************************************************************************
      * @author      manvil95
      * @date        24/05/2024
@@ -28,7 +58,6 @@ public with sharing class TRG_CAMPX_GardenHelper {
      * @comments
     **********************************************************************************************/
     public static void setUnsetManagerStartDate(List<CAMPX__Garden__c> newTriggerList, Map<Id, CAMPX__Garden__c> oldTriggerMap) {
-        
         for (CAMPX__Garden__c currentGarden : newTriggerList) {
             if ((currentGarden.CAMPX__Manager__c != null && oldTriggerMap == null)
                     || (

--- a/force-app/main/default/classes/TRG_CAMPX_GardenHelper_Test.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHelper_Test.cls
@@ -36,6 +36,74 @@ public with sharing class TRG_CAMPX_GardenHelper_Test {
 
     /**************************************************************************************************
      * @author      manvil95
+     * @date        04/06/2024
+     * @modifiedBy
+     * @description When a garden record is updated the capacity is calculated.
+     * @comments
+    **************************************************************************************************/
+    @isTest
+    static void calculateCapacityOnUpdate() {
+        List<CAMPX__Garden__c> testGardens = new List<CAMPX__Garden__c>();
+        for (Integer i = 0; i < 5; i++) {
+            CAMPX__Garden__c currentGarden = new CAMPX__Garden__c(
+                Name = 'Garden ' + i,
+                CAMPX__Manager__c = UserInfo.getUserId(),
+                CAMPX__Total_Plant_Count__c = 50,
+                CAMPX__Max_Plant_Count__c = 100
+            );
+            testGardens.add(currentGarden);
+        }
+        
+        insert testGardens;
+        
+        for (CAMPX__Garden__c campx : testGardens) {
+            campx.CAMPX__Total_Plant_Count__c = 51;
+        }
+        
+        Test.startTest();
+        update testGardens;
+        Test.stopTest();
+
+        List<CAMPX__Garden__c> gardenInserted = [SELECT Id, CAMPX__Capacity__c FROM CAMPX__Garden__c];
+
+        for (CAMPX__Garden__c currentGarden : gardenInserted) {
+            System.assertEquals(51, currentGarden.CAMPX__Capacity__c, 'Capacity is not the expected.');
+        }
+    }
+
+    /**************************************************************************************************
+     * @author      manvil95
+     * @date        04/06/2024
+     * @modifiedBy
+     * @description When a garden record is created the capacity is calculated.
+     * @comments
+    **************************************************************************************************/
+    @isTest
+    static void calculateCapacity() {
+        List<CAMPX__Garden__c> testGardens = new List<CAMPX__Garden__c>();
+        for (Integer i = 0; i < 5; i++) {
+            CAMPX__Garden__c currentGarden = new CAMPX__Garden__c(
+                Name = 'Garden ' + i,
+                CAMPX__Manager__c = UserInfo.getUserId(),
+                CAMPX__Total_Plant_Count__c = 50,
+                CAMPX__Max_Plant_Count__c = 100
+            );
+            testGardens.add(currentGarden);
+        }
+        
+        Test.startTest();
+        insert testGardens;
+        Test.stopTest();
+
+        List<CAMPX__Garden__c> gardenInserted = [SELECT Id, CAMPX__Capacity__c FROM CAMPX__Garden__c];
+
+        for (CAMPX__Garden__c currentGarden : gardenInserted) {
+            System.assertEquals(50, currentGarden.CAMPX__Capacity__c, 'Capacity is not the expected.');
+        }
+    }
+
+    /**************************************************************************************************
+     * @author      manvil95
      * @date        25/05/2024
      * @modifiedBy
      * @description When a garden record is updated and a manager is unset, start date must be blank.


### PR DESCRIPTION
### Description

User Story:
As a Garden Manager, I want the system to calculate the capacity of my garden, so I can understand how full my garden is.


Acceptance Criteria:

"Capacity" (CAMPX__Capacity__c) should be calculated whenever the "Total Plant Count" (CAMPX__Total_Plant_Count__c) or "Maximum Plant Count" (CAMPX__Max_Plant_Count__c) change
The formula is: (Total Plant Count / Maximum Plant Count) × 100
When Maximum Plant Count or Total Plant Count is zero or blank, the Capacity should be zero

Example Scenario:

The Rose Garden has a Total Plant Count of 50 and a Maximum Plant Count of 100. Capacity is 50%. A new rose bush was added to the Rose Garden and increased the Total Plant Count to 51. The capacity is now 51%.
The Greenhouse Garden has a Total Plant Count of 2 and a Maximum Plant Count of 100. Capacity is 2%. One of the plants is removed, and the Total Plant Count drops to 1. The capacity is now 1%.
The Spring Garden has a Total Plant Count of 100 and a Maximum Plant Count of 100. Capacity is at 100%. The Maximum Plant Count increased to 120. The Capacity is now at 83.33%.


### Apex Tests to Run

Apex::[TRG_CAMPX_GardenHelper_Test,TRG_CAMPX_PlantHelper_Test,TriggerHandler_Test]::Apex