### PR TITLE
Feature/aggregate unhealthy plant count

### DIFF
--- a/force-app/main/default/classes/TRG_CAMPX_PlantHandler.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_PlantHandler.cls
@@ -46,6 +46,7 @@ public with sharing class TRG_CAMPX_PlantHandler extends TriggerHandler {
     **************************************************************************************************/
     public override void afterInsert() { 
         TRG_CAMPX_PlantHelper.aggregateTotalPlantCount(this.listNew, null);
+        TRG_CAMPX_PlantHelper.calculateUnhealthyPlantCount(this.listNew, null);
     }
     
     /**************************************************************************************************
@@ -57,6 +58,7 @@ public with sharing class TRG_CAMPX_PlantHandler extends TriggerHandler {
      **************************************************************************************************/
     public override void afterUpdate() { 
         TRG_CAMPX_PlantHelper.aggregateTotalPlantCount(this.listNew, this.mapOld);
+        TRG_CAMPX_PlantHelper.calculateUnhealthyPlantCount(this.listNew, this.mapOld);
     }
     
     /**************************************************************************************************
@@ -68,5 +70,6 @@ public with sharing class TRG_CAMPX_PlantHandler extends TriggerHandler {
     **************************************************************************************************/
     public override void afterDelete() {
         TRG_CAMPX_PlantHelper.aggregateTotalPlantCount(this.listOld, null);
+        TRG_CAMPX_PlantHelper.calculateUnhealthyPlantCount(this.listOld, null);
     }
 }

--- a/force-app/main/default/classes/TRG_CAMPX_PlantHelper.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_PlantHelper.cls
@@ -12,6 +12,59 @@
  **************************************************************************************************/
 public with sharing class TRG_CAMPX_PlantHelper {
     
+    private static final String ALL_PURPOSE_POTTING_SOIL    = 'All Purpose Potting Soil';
+    private static final String ONCE_WEEKLY                 = 'Once Weekly';
+    private static final String PARTIAL_SUN                 = 'Partial Sun';
+
+    /**********************************************************************************************
+     * @author      manvil95
+     * @date        13/06/2024
+     * @modifiedBy
+     * 
+     * @param       newTriggerList : Trigger.new
+     * @param       oldTriggerMap  : Trigger.oldMap
+     * 
+     * @description Method to calculate the total unhealthy plant count
+     * @comments
+    **********************************************************************************************/
+    public static void calculateUnhealthyPlantCount(List<CAMPX__Plant__c> newTriggerList, Map<Id, CAMPX__Plant__c> oldTriggerMap) {
+        Set<Id> uniqueGardenIds                 = new Set<Id>();
+        List<CAMPX__Garden__c> gardensToUpdate  = new List<CAMPX__Garden__c>();
+
+        for (CAMPX__Plant__c currentPlant : newTriggerList) {
+            if (currentPlant.MV_FOR_IsHealthy__c != true 
+                    || (oldTriggerMap != null && currentPlant.MV_FOR_IsHealthy__c != oldTriggerMap.get(currentPlant.Id).MV_FOR_IsHealthy__c)) {
+                uniqueGardenIds.add(currentPlant.CAMPX__Garden__c);
+            }
+            if (oldTriggerMap != null && currentPlant.CAMPX__Garden__c != oldTriggerMap.get(currentPlant.Id).CAMPX__Garden__c) {
+                uniqueGardenIds.add(oldTriggerMap.get(currentPlant.Id).CAMPX__Garden__c);
+            }
+        }
+
+        if (!uniqueGardenIds.isEmpty()) {
+            gardensToUpdate = [SELECT Id, 
+                                (
+                                    SELECT Id 
+                                    FROM CAMPX__Plants__r 
+                                    WHERE MV_FOR_IsHealthy__c != true
+                                )
+                            FROM CAMPX__Garden__c 
+                            WHERE Id IN :uniqueGardenIds
+                            WITH USER_MODE];
+                            
+            for (CAMPX__Garden__c currentGarden : gardensToUpdate) {
+                currentGarden.CAMPX__Total_Unhealthy_Plant_Count__c = currentGarden.CAMPX__Plants__r.size();
+                System.debug('MVC count ' + currentGarden.CAMPX__Total_Unhealthy_Plant_Count__c);
+            }
+        }
+
+        try {
+            update gardensToUpdate;
+        } catch (Exception e) {
+            System.debug(e.getMessage());
+        } 
+    }
+
     /**********************************************************************************************
      * @author      manvil95
      * @date        10/05/2024
@@ -83,18 +136,18 @@ public with sharing class TRG_CAMPX_PlantHelper {
         
         for (CAMPX__Plant__c currentPlant : newTriggerList) {
             if (currentPlant.CAMPX__Soil_Type__c == null) {
-                currentPlant.CAMPX__Soil_Type__c = 'All Purpose Potting Soil';
+                currentPlant.CAMPX__Soil_Type__c = ALL_PURPOSE_POTTING_SOIL;
             }
             
             if (currentPlant.CAMPX__Water__c == null) {
-                currentPlant.CAMPX__Water__c = 'Once Weekly';
+                currentPlant.CAMPX__Water__c = ONCE_WEEKLY;
             }
             
             if (currentPlant.CAMPX__Garden__c != null && gardenParents.get(currentPlant.CAMPX__Garden__c).CAMPX__Sun_Exposure__c != '' && gardenParents.get(currentPlant.CAMPX__Garden__c).CAMPX__Sun_Exposure__c != null) {
                 currentPlant.CAMPX__Sunlight__c = gardenParents.get(currentPlant.CAMPX__Garden__c).CAMPX__Sun_Exposure__c;
             }
             else if (currentPlant.CAMPX__Sunlight__c == null) {
-                currentPlant.CAMPX__Sunlight__c = 'Partial Sun';
+                currentPlant.CAMPX__Sunlight__c = PARTIAL_SUN;
             }
             
             plantsToInsert.add(currentPlant);

--- a/force-app/main/default/objects/CAMPX__Plant__c/fields/MV_FOR_IsHealthy__c.field-meta.xml
+++ b/force-app/main/default/objects/CAMPX__Plant__c/fields/MV_FOR_IsHealthy__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>MV_FOR_IsHealthy__c</fullName>
+    <description>Field to indicate whether a plant is healthy or not depending on its status.</description>
+    <externalId>false</externalId>
+    <formula>ISPICKVAL(CAMPX__Status__c, &apos;Healthy&apos;)</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>Is Healthy</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>


### PR DESCRIPTION
### Description

User Story:
As a Garden Manager, I want the garden record to keep track of the number of unhealthy plants it has, so I can accurately report on and monitor the health status of my garden.


Acceptance Criteria:

The garden's "Total Unhealthy Plant Count" (CAMPX__Total_Unhealthy_Plant_Count__c) should count/sum the number of child plant records whose status is: Sick, Deceased, or Wilting
The field value must increase when a plant's status changes from healthy to unhealthy
The field value must decrease when a plant's status changes from unhealthy to healthy
The field value must decrease when a plant leaves the garden (if it's deleted or reparented)
The field value must increase when a sick plant enters the garden (if it's reparented)

Example Scenario:

A fern in the Tropical Garden is marked as wilting, resulting in the "Total Unhealthy Plant Count" for the Tropical Garden incrementing by one.
A sick orchid in the Orchid Garden is cured, and its status is updated to healthy, leading to a decrease in the "Unhealthy Plant Count" for the Orchid Garden.
A deceased sunflower in the Sunflower Garden is removed, causing the "Total Unhealthy Plant Count" for the Sunflower Garden to decrease by one.
A plant in the Herb Garden changes status from wilting to diseased, the "Total Unhealthy Plant Count" for the Herb Garden remains unchanged

### Apex Tests to Run

Apex::[TRG_CAMPX_GardenHelper_Test,TRG_CAMPX_PlantHelper_Test,TriggerHandler_Test]::Apex