### PR TITLE
Feature/calculate health index

### DIFF
--- a/force-app/main/default/classes/TRG_CAMPX_GardenHandler.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHandler.cls
@@ -37,6 +37,7 @@ public with sharing class TRG_CAMPX_GardenHandler extends TriggerHandler{
         TRG_CAMPX_GardenHelper.initializeGardenFieldsUponRecordCreation(this.listNew);
         TRG_CAMPX_GardenHelper.setUnsetManagerStartDate(this.listNew, null);
         TRG_CAMPX_GardenHelper.calculateCapacity(this.listNew, null);
+        TRG_CAMPX_GardenHelper.calculateHealthIndex(this.listNew, null);
     }
     
     /**************************************************************************************************
@@ -60,6 +61,7 @@ public with sharing class TRG_CAMPX_GardenHandler extends TriggerHandler{
     public override void beforeUpdate() {
         TRG_CAMPX_GardenHelper.setUnsetManagerStartDate(this.listNew, this.mapOld);
         TRG_CAMPX_GardenHelper.calculateCapacity(this.listNew, this.mapOld);
+        TRG_CAMPX_GardenHelper.calculateHealthIndex(this.listNew, this.mapOld);
     }
 
     /**************************************************************************************************

--- a/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
+++ b/force-app/main/default/classes/TRG_CAMPX_GardenHelper.cls
@@ -18,6 +18,33 @@ public with sharing class TRG_CAMPX_GardenHelper {
 
     /**********************************************************************************************
      * @author      manvil95
+     * @date        13/06/2024
+     * @modifiedBy
+     * 
+     * @param       newTriggerList : Trigger.new
+     * @param       oldTriggerMap  : Trigger.oldMap
+     * 
+     * @description Method to calculate the health index.
+     * @comments
+    **********************************************************************************************/
+    public static void calculateHealthIndex(List<CAMPX__Garden__c> newTriggerList, Map<Id, CAMPX__Garden__c> oldTriggerMap) {
+        for (CAMPX__Garden__c currentGarden : newTriggerList) {
+            if (
+                    oldTriggerMap == null 
+                    || (currentGarden.CAMPX__Total_Plant_Count__c != oldTriggerMap.get(currentGarden.Id).CAMPX__Total_Plant_Count__c)
+                    || (currentGarden.CAMPX__Total_Unhealthy_Plant_Count__c != oldTriggerMap.get(currentGarden.Id).CAMPX__Total_Unhealthy_Plant_Count__c)
+            ) {
+                if (currentGarden.CAMPX__Total_Plant_Count__c != null && currentGarden.CAMPX__Total_Unhealthy_Plant_Count__c != null && currentGarden.CAMPX__Total_Plant_Count__c != 0) {
+                    currentGarden.CAMPX__Health_Index__c = ((currentGarden.CAMPX__Total_Plant_Count__c - currentGarden.CAMPX__Total_Unhealthy_Plant_Count__c) / currentGarden.CAMPX__Total_Plant_Count__c) * 100;
+                } else {
+                    currentGarden.CAMPX__Health_Index__c = 0;
+                }
+            }
+        }
+    }
+
+    /**********************************************************************************************
+     * @author      manvil95
      * @date        04/06/2024
      * @modifiedBy
      * 

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -43,6 +43,7 @@
         <members>CAMPX__Plant__c.CAMPX__Sunlight__c</members>
         <members>CAMPX__Plant__c.CAMPX__Type__c</members>
         <members>CAMPX__Plant__c.CAMPX__Water__c</members>
+        <members>CAMPX__Plant__c.MV_FOR_IsHealthy__c</members>
         <name>CustomField</name>
     </types>
     <types>


### PR DESCRIPTION
### Description

User Story:
As a Garden manager, I want the system to calculate the health index of a garden, so I can understand its health status and prioritize gardens for maintenance.


Acceptance Criteria:

The garden's "Health Index" (CAMPX__Health_Index__c) field should be set based on this formula: ((Total Plant Count - Total Unhealthy Plant Count)/Total Plant Count) * 100
The field must be recalculated and updated when there is a change in either the "Total Plant Count" or "Total Unhealthy Plant Count"
The field should be 0 if the "Total Plant Count" is zero or blank

Example Scenario:

In the garden, there are initially 50 total roses, 5 of which are unhealthy. After adding 5 new healthy roses, the "Health Index" is ((55 - 5) / 55) * 100 = 90.91.
The Fern Garden has 40 total ferns, with 3 unhealthy. When another fern is marked unhealthy, the total unhealthy becomes 4. The "Health Index" is ((40 - 4) / 40) * 100 = 90.00.
If all 10 plants in a Herb Garden are removed, the "Health Index" would be ((0 - 10) / 0) * 100 = 0.

### Apex Tests to Run

Apex::[TRG_CAMPX_GardenHelper_Test,TRG_CAMPX_PlantHelper_Test,TriggerHandler_Test]::Apex